### PR TITLE
日本語版のページへのリンク先が間違っていた問題を修正

### DIFF
--- a/index.MD
+++ b/index.MD
@@ -3,7 +3,7 @@ title: DripLog
 layout: default
 permalink: /
 ---
-[English](/index_en.MD)
+[English](https://yukiats.github.io/driplog-site/index_en.MD)
 
 ## DripLogとは？
 DripLogは看護師が考えた作成した点滴速度と実施履歴と記録を統合管理できるアプリです。  

--- a/index_en.MD
+++ b/index_en.MD
@@ -3,7 +3,7 @@ title: DripLog
 layout: default
 permalink: /index-en/
 ---
-[Japanese(日本語)](/)
+[Japanese(日本語)](https://yukiats.github.io/driplog-site/)
 
 ## What is DripLog?
 DripLog is an app created by nurses to centrally manage drip rate calculations, infusion histories, and records.  


### PR DESCRIPTION
日本語版のページへのリンク先が間違っていた問題を修正
Fixed hyper link for Japanese version of index.MD.